### PR TITLE
Add second set of logos to top of page and fix responsiveness mismatch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -119,7 +119,19 @@
       </p>
     </div>
   </header>
-  <main class="w-full lg:w-1/2 md:w-2/3 mx-auto my-16 px-9 md:px-0 text-gray-700">
+  <main class="w-full xl:w-1/2 md:w-2/3 mx-auto my-16 px-9 md:px-0 text-gray-700">
+    <div class="hidden md:flex flex-col md:flex-row justify-center items-center gap-8 my-16">
+      <a href="https://www.youngandunited.nl/home#/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-fnv-yu.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+      <a href="https://lsvb.nl/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-lsvb.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+      <a href="https://groningerstudentenbond.nl/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-gsb.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+    </div>
+
     <section>
       <h2 class="text-4xl font-black text-black leading-8 tracking-tight font-tw">
         Maak schuldenvrij studeren en compensatie mogelijk!
@@ -139,6 +151,18 @@
         Teken de petitie
       </a>
     </section>
+
+    <div class="md:hidden flex flex-col md:flex-row justify-center items-center gap-8 my-16">
+      <a href="https://www.youngandunited.nl/home#/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-fnv-yu.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+      <a href="https://lsvb.nl/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-lsvb.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+      <a href="https://groningerstudentenbond.nl/" target="_blank" rel="noopener noreferrer">
+        <img src="./img/logo-gsb.png" alt="" class="max-h-16 max-w-32 grayscale opacity-80"/>
+      </a>
+    </div>
 
     <section>
       <h2 class="text-4xl font-black text-black leading-8 tracking-tight font-tw mt-16">Wat feitjes op rijtjes</h2>


### PR DESCRIPTION
This PR adds a second set of logos to the top of the page, which shows directly under the red section ór under the call to action, depending on the screen size. See attached screenshots.

Signed-off-by: Jurriaan Den Toonder <1493561+Fastjur@users.noreply.github.com>

![desktop](https://user-images.githubusercontent.com/1493561/108245030-1d6df580-7150-11eb-815a-548a9bbf9603.png)
![mobile](https://user-images.githubusercontent.com/1493561/108245037-1f37b900-7150-11eb-9cc8-7ac647f11b4a.png)
